### PR TITLE
Adjustable Popup Modal Height

### DIFF
--- a/client/lazy/components/ol/ol.css
+++ b/client/lazy/components/ol/ol.css
@@ -62,6 +62,11 @@
     }
 }
 
+.wrapper > slot {
+    display: block;
+    overflow-y: auto;
+}
+
 .backgroundcover {
     position: absolute;
     width: 100%;

--- a/client/lazy/components/ol/ol.ts
+++ b/client/lazy/components/ol/ol.ts
@@ -359,10 +359,12 @@ class COl extends HTMLElement {
         const wrapper_el = this.shadow.querySelector(".wrapper") as HTMLElement
 
         wrapper_el.style.width = this.s.width
-        wrapper_el.style.height = this.s.height
+        wrapper_el.style.maxHeight = this.s.height
         wrapper_el.style.top = this.s.top
         wrapper_el.style.left = this.s.left
         wrapper_el.style.marginLeft = this.s.margin_left
+        wrapper_el.style.display = 'block grid';
+        wrapper_el.style.gridTemplateRows = 'auto 1fr';
 
 		if (this.s.is_mobile_centric) {
 			wrapper_el.classList.add("mobile_centric")


### PR DESCRIPTION
Currently, the popup modal's (`COl` class) height is fixed. If the content is short (height), the remaining bottom of the popup modal is left with empty space. Not only is this visually odd, but this could give users on a small device (eg, phone) of a certain setup, give a false impression that there are still more content, when there is none.

To avoid this, we make the popup modal's height adjustable with a maximum height.

This should be applied along with the `client_pwd` changes: [https://github.com/Pure-Water-Tech/client_pwt/pull/2](https://github.com/Pure-Water-Tech/client_pwt/pull/2)

Sample using a modified **Machines** > **Notifications** popup modal for quick demonstration:

[popup-modal-dynamic-height.webm](https://github.com/user-attachments/assets/4823fb14-4dd4-43ee-bb17-ad01294c0307)

Below are screenshots of popup modals: current / before any changes, with the `nifty` changes, and with both `nifty` and `client_pwt` (PR: [https://github.com/Pure-Water-Tech/client_pwt/pull/2](https://github.com/Pure-Water-Tech/client_pwt/pull/2)) changes:

| Page | Before | After (`nifty` only) | After (`nifty` and `client_pwt`
| -- | -- | -- | --
| Machines > Notifications | ![image](https://github.com/user-attachments/assets/89e58d49-02b9-4776-9159-fa96579adbfb) | ![image](https://github.com/user-attachments/assets/45b9972a-082e-473f-9b1b-4a4f7ee4cb86) | ![image](https://github.com/user-attachments/assets/a4c81fe1-963f-44cd-9581-9adf598005db)
| Machines > Machine > Details | ![image](https://github.com/user-attachments/assets/f749dcf8-9038-4a47-b7f9-4bcfd194d006) | ![image](https://github.com/user-attachments/assets/8a8a90d6-c8ce-4ebf-9216-3fce5e407662) | ![image](https://github.com/user-attachments/assets/35838249-fd0c-4410-8424-dcce7377e9f2)
| Machines > Machine > Edit | ![image](https://github.com/user-attachments/assets/ddaf55eb-c4a3-450f-b056-76070a21ae2f) | ![image](https://github.com/user-attachments/assets/7d6bcf36-c382-4b35-85f6-b58e8e254309) | ![image](https://github.com/user-attachments/assets/517d8f62-cfbd-4c89-a446-669a46f09d65)
| Machines > Machine > Map | ![image](https://github.com/user-attachments/assets/36485152-4024-47e5-b074-795edb23ec38) | ![image](https://github.com/user-attachments/assets/28839559-c2c6-4885-8044-a2606cfd5599) | ![image](https://github.com/user-attachments/assets/d295f0f3-356b-4e35-800b-1784772e926e)
| Machines > Machine > Telemetry > Settings | ![image](https://github.com/user-attachments/assets/ff4a0394-b18d-45e3-9af9-1511bafdf27f) | ![image](https://github.com/user-attachments/assets/c74554b0-24eb-4dd5-b985-686f640a134b) | ![image](https://github.com/user-attachments/assets/69eef95e-df71-4e3f-a4d2-642c729e0a2b)





